### PR TITLE
Using separate data and annotations with the BatchGenerator class

### DIFF
--- a/generatorTest.py
+++ b/generatorTest.py
@@ -14,16 +14,18 @@ h5filename = 'db_h5__file'
 # open h5d database for reading
 db = dbi.open_file(h5filename, 'r')
 print(db)
-train_data = dbi.open_table(db, "/train")
-val_data = dbi.open_table(db, "/eval")
-test_data = dbi.open_table(db, "/test")
+train_data = dbi.open_table(db, "/train/table_data")
+train_annot = dbi.open_table(db,"/train/table_annot")
+val_data = dbi.open_table(db, "/eval/table_data")
+val_annot = dbi.open_table(db,"/eval/table_annot")
+test_data = dbi.open_table(db, "/test/table_data")
+test_annot = dbi.open_table(db, "/test/table_annot")
 
 
 
-train_generator = BatchGenerator(batch_size=128, data_table=train_data, annot_in_data_table=True,
-                                  shuffle=True, refresh_on_epoch_end=True)
+train_generator = BatchGenerator(batch_size=128, data_table=train_data, annot_table=train_annot, annot_in_data_table=False,shuffle=True, refresh_on_epoch_end=True)
 
-val_generator = BatchGenerator(batch_size=128, data_table=val_data, annot_in_data_table=True,
+val_generator = BatchGenerator(batch_size=32, data_table=val_data, annot_in_data_table=True,
                                  shuffle=True, refresh_on_epoch_end=False)
 
 


### PR DESCRIPTION
HI Val,

Please have a look at the small changes I made to your code.
I think now it does what you were expecting.

The issue was that your data and annotations are in separate tables within your HDF5 database.
This is fine and supported by the BatchGenerator class, but in this case, you need to pass both the data_table and annot_table arguments when creating a generator.

If your annotations were together with the data in your data tables, then you could do what you tried: pass only the data_table and set annot_in_data_table to True.

I also changed the batch size in your val_generator to 32, which is the number of samples in your example. This is the default behavior for the BatchGrenerator anyway: if you specify a batch_size that is larger than the number of samples you have, it'll automatically adjust the size to that maximum and give you a warning.

If you are interested in creating a batch generator that actually resamples the dataset to fulfill a batch size larger than the number of samples in the dataset (i.e.: by including some samples multiple times), have a look at the [JointBatchGen](https://docs.meridian.cs.dal.ca/ketos/modules/data_handling/data_feeding.html?highlight=joint#ketos.data_handling.data_feeding.JointBatchGen) class. It allows you to combine several batch generators (or multiple copies of the same).

